### PR TITLE
Fixed Issue were the greeting was displaying, when already logged in.

### DIFF
--- a/nodeChatReact/src/chatPage/chatPage.js
+++ b/nodeChatReact/src/chatPage/chatPage.js
@@ -13,7 +13,8 @@ class ChatPage extends Component {
             chatLog: [],
             greeting: '',
             connected: props.connected,
-            username: props.username
+            username: props.username,
+            previousUser: props.previousUser
         };
         this.setChatInput = this.setChatInput.bind(this);
         this.enterKeyPress = this.enterKeyPress.bind(this);
@@ -21,7 +22,9 @@ class ChatPage extends Component {
     componentDidMount() {
         if (this.state.connected) {
             // Create a greeting message for the newly connected user
-            this.greetUser();
+            if(!this.state.previousUser){
+                this.greetUser();
+            }
             this.state.socket.on('new message', (message) => {
                 this.addChatMessage(message);
                 if(this.state.username !== message.username){

--- a/nodeChatReact/src/loginPage/loginPage.js
+++ b/nodeChatReact/src/loginPage/loginPage.js
@@ -15,6 +15,7 @@ class LoginPage extends Component {
             username: '',
             usernameInput: '',
             isLoggedIn: false,
+            previousUser: false,
             socket: '',
             connected: false
         };
@@ -76,6 +77,7 @@ class LoginPage extends Component {
 
             // Set the global variable that the user is connected
             this.setState({ connected: true });
+            this.setState({ previousUser: true });
         }
         // If the user did not have a username saved in localstorage then we hide the chatPage
         // login page will show, which gets the username from the user.
@@ -111,6 +113,7 @@ class LoginPage extends Component {
             currentPage = <ChatPage socket={this.socket}
                 connected={this.state.connected}
                 username={this.state.username}
+                previousUser={this.state.previousUser}
             />;
         } else {
             currentPage = this.displayLogin();


### PR DESCRIPTION
This pull request removes the greeting message that was displaying when a user joins that has already logged in. 

This makes it so the greeting message is displayed only after a user log's in for the first time. I noticed this is how the original site functions.
