### PR TITLE
Hide "{user} is typing" message when user isn't typing

### DIFF
--- a/src/chatPage/chatPage.js
+++ b/src/chatPage/chatPage.js
@@ -24,6 +24,7 @@ class ChatPage extends Component {
         this.enterKeyPress = this.enterKeyPress.bind(this);
         this.Logout = this.Logout.bind(this);
     }
+    
     componentDidMount() {
         if (this.state.connected) {
             // Create a greeting message for the newly connected user
@@ -53,8 +54,8 @@ class ChatPage extends Component {
                 }
             });
         }
-
     }
+
     greetUser() {
         // Create a span with the greeting message
         var userGreeting = <span className="messageBody">Hello there {this.state.username}!</span>;
@@ -70,12 +71,13 @@ class ChatPage extends Component {
         if (e.keyCode === 13) {
             this.sendMessage();
             this.setState({ chatInput: '' });
+            this.state.socket.emit('stop typing', this.state.username);
         }
     }
     setChatInput(event) {
         if(event.target.value !== ""){
             this.state.socket.emit('typing', this.state.username);
-        } else if(event.target.value === ""){
+        } else {
             this.state.socket.emit('stop typing', this.state.username);
         }
         this.setState({ chatInput: event.target.value });


### PR DESCRIPTION
Fixes #61

It looks like the code for this was already there just not being called. I moved some function calls around to ensure that The "{user} is typing" message will now disappear once the message has been sent or if the message input field is empty.