### PR TITLE
Added prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,24 @@
 {
     "parser": "babel-eslint",
-    "plugins": [
-        "react"
+    "extends": [
+        "airbnb",
+        "prettier",
+        "prettier/react"
     ],
-    "rules":{
+    "plugins": [
+        "prettier"
+    ],
+    "rules": {
+        "prettier/prettier": ["error"],
+        "quotes": ["error", "double"],
+        "indent": ["error", "tab"],
+        "react/jsx-indent": ["error", "tab"],
+        "react/jsx-one-expression-per-line": 0,
+        "react/jsx-filename-extension": [1, {"extensions": [".js",".jsx"]}],
+        "react/prop-types": 0,
+        "no-underscore-dangle": 0,
+        "import/imports-first": ["error","absolute-first"],
+        "import/newline-after-import": "error",
         "no-undef": [1],
         "no-console": [1]
     }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+    "trailingComma": "es5",
+    "useTabs": true,
+    bracketSpacing: true,
+    jsxBracketSameLine: true,
+    semi: true
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "fix-code": "prettier-eslint --write 'src/**/*.{js,jsx}' ",
+    "fix-styles": "prettier-stylelint --write 'src/**/*.{css,scss}' "
   },
   "repository": {
     "type": "git",
@@ -20,7 +22,13 @@
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
-    "eslint-plugin-react": "^7.11.1"
+    "eslint-config-prettier": "^3.3.0",
+    "eslint-plugin-prettier": "^3.0.0",
+    "eslint-plugin-react": "^7.11.1",
+    "prettier": "^1.15.3",
+    "prettier-eslint": "^8.8.2",
+    "prettier-eslint-cli": "^4.7.1",
+    "prettier-stylelint": "^0.4.2"
   },
   "dependencies": {
     "push.js": "0.0.11",

--- a/src/chatPage/test.js
+++ b/src/chatPage/test.js
@@ -1,0 +1,16 @@
+import React, { Component } from "react";
+import "./chatPage.css";
+import * as Push from "push.js";
+
+class ChatPage extends Component {
+	greetUserName() {
+		// Create a span with the greeting message
+		const userGreeting = (
+			<span className="messageBody">Hello there{this.state.username}!</span>
+		); // Create a container for the message text
+		const greetingContainer = <li className="message">{userGreeting}</li>;
+		// Add the greeting to t    he chat log
+
+		this.setState({ greeting: greetingContainer });
+	}
+}


### PR DESCRIPTION
#51 was closed via #69, however prettier was not added.

This pr adds prettier configuration and rules.

Also added 2 commands - fix-code (fixes js) and fix-styles (fixes css). 
Usage: `npm run fix-code`. Changes will be made in src directory and all subdirectories.

Before:
<img width="1392" alt="screen shot 2018-12-05 at 12 04 58" src="https://user-images.githubusercontent.com/8983928/49537611-6d29b480-f897-11e8-8dd3-8834027ac06f.png">

After: - code formatted according to the rules (spacing, ' replaced with ", added missing semicolons;)
<img width="1392" alt="screen shot 2018-12-05 at 12 04 26" src="https://user-images.githubusercontent.com/8983928/49537616-6f8c0e80-f897-11e8-97e2-390d713f8361.png">

